### PR TITLE
Improve performance when mergin overlapping timed data series

### DIFF
--- a/src/data_timeseries.h
+++ b/src/data_timeseries.h
@@ -516,6 +516,8 @@ public:
         /*****************
          *  MERGING IN
          *****************/
+        _elems_time.reserve(_elems_time.size()+src->_elems_time.size());
+        _elems_data.reserve(_elems_data.size()+src->_elems_data.size());
         const bool do_fast_merge = (tmax_src < tmin_me) || (tmin_src > tmax_me); ///< checks for non-overlapping time ranges
         if (do_fast_merge) {
             if (dt_sec > 0.) {
@@ -531,24 +533,46 @@ public:
             }
         } else {
             // INSERT: data is overlapping...we have to sort-in every single data item
-            for (unsigned int k=0; k<src->_elems_time.size(); ++k) {
-                double tsrc = src->_elems_time[k];
-                if (dt_sec < 0.) {
-                    // adjust source's time
-                    tsrc = src->_elems_time[k] - dt_sec;
-                }
-                T datasrc = src->_elems_data[k];
-                std::vector<double>::iterator first_greater_time = std::upper_bound(_elems_time.begin(), _elems_time.end(), tsrc); // returns iterator to first element t1 where t1 > t holds true
-                if (first_greater_time != _elems_time.end()) {
-                    // insert before first_greater
-                    typename std::vector<T>::iterator first_greater_data = _elems_data.begin() + (first_greater_time - _elems_time.begin()); // calc index from iterator
-                    _elems_time.insert(first_greater_time, tsrc);
-                    _elems_data.insert(first_greater_data, datasrc);
-                } else {
-                    // there was none greater...append
-                    _elems_time.push_back(tsrc);
-                    _elems_data.push_back(datasrc);
-                }
+
+            //merge time and data arrays into one array (SOA to AOS) for both our data and other data
+            struct TimedData{
+                double time;
+                T data;
+                bool operator<(const TimedData& r){ return time < r.time; }
+            };
+            std::vector<TimedData> own(_elems_time.size());
+            for (size_t cnt = 0; cnt < _elems_time.size(); cnt++) {
+                own[cnt] = TimedData{_elems_time[cnt], _elems_data[cnt]};
+            }
+
+            std::vector<TimedData> others(src->_elems_time.size());
+            for (size_t cnt = 0; cnt < src->_elems_time.size(); cnt++) {
+                others[cnt] = TimedData{src->_elems_time[cnt] - dt_sec, src->_elems_data[cnt]};
+            }
+
+            //merge the two series
+
+            //c++11:
+            //    assert(std::is_sorted(own.begin(),own.end()),"Other data is not sorted");
+            //    assert(std::is_sorted(others.begin(),others.end()),"Other data is not sorted");
+
+            const size_t total_size = _elems_time.size() + src->_elems_time.size();
+            std::vector<TimedData> merged(total_size);
+            std::merge(
+                        own.begin(),
+                        own.end(),
+                        others.begin(),
+                        others.end(),
+                        merged.begin()
+                        );
+
+            //split array containing time and data back into separate arrays
+            _elems_time.resize(total_size);
+            _elems_data.resize(total_size);
+
+            for (std::size_t i = 0; i < total_size; ++i) {
+                _elems_time[i] = merged[i].time;
+                _elems_data[i] = merged[i].data;
             }
         }
 


### PR DESCRIPTION
Instead of inserting each value into the original data series individually (which requires shifting the data around each time), both data series get merged into a newly allocated buffer and the result is then copied back into the original one (In total O(N+M) instead of O(N*M)).

On the last set of flight data this improved loading time on my machine from ~8min to ~20s. Should work with pre c++11 compilers, but I only tested it with MSVC2017