### PR TITLE
PortMavLogAnalyzer to MSVC

### DIFF
--- a/src/MavLogAnalyzer.pro
+++ b/src/MavLogAnalyzer.pro
@@ -63,14 +63,20 @@ TEMPLATE = app
 ###########################
 # this points to generated MavLink headers
 INCLUDEPATH += $$MAVLINK_COMMON $$QWT_INCPATH
-LIBS+= -L $$QWT_LIBPATH
+LIBS+= -L$$QWT_LIBPATH
 
 ###########################
 #    CPPFLAGS/LFLAGS
 ###########################
-QMAKE_CXXFLAGS += -Wall -fpermissive -DWITH_DATAREGEX
-QMAKE_CXXFLAGS_RELEASE += -O3
-QMAKE_CXXFLAGS_DEBUG += -O0
+gcc {
+    QMAKE_CXXFLAGS += -Wall -std=c++11 -DWITH_DATAREGEX
+    QMAKE_CXXFLAGS_RELEASE += -O3
+    QMAKE_CXXFLAGS_DEBUG += -O0
+}
+win32-msvc {
+    QMAKE_CXXFLAGS += -DQWT_DLL -DWITH_DATAREGEX
+}
+
 #QMAKE_CXXFLAGS_DEBUG += -pg -p
 #QMAKE_LFLAGS_DEBUG += -pg
 #QMAKE_CXXFLAGS += -Werror

--- a/src/cmdlineargs.cpp
+++ b/src/cmdlineargs.cpp
@@ -23,7 +23,9 @@
 
 #include <stdio.h> // FIXME: rem
 #include <cstdlib> // atof
+#ifndef _MSC_VER
 #include <getopt.h>
+#endif
 #include "cmdlineargs.h"
 #include "filefun.h"
 
@@ -53,6 +55,7 @@ bool CmdlineArgs::_file_exists(std::string filename) {
 }
 
 int CmdlineArgs::_parse(int argc, char**argv) {
+#ifndef _MSC_VER
     const char *const short_options = "hnj:i"; /* A string listing valid short options letters.  */
     /* An array describing valid long options.  */
     const struct option long_options[] = {
@@ -112,6 +115,7 @@ int CmdlineArgs::_parse(int argc, char**argv) {
             }            
         }
     }
+#endif
     return 0;
 }
 

--- a/src/config.h
+++ b/src/config.h
@@ -24,7 +24,10 @@
 #define CONFIG_H
 
 // to suppres warnings for purposely not used parameters (e.g., for polymorphism)
-#define ATTR_UNUSED __attribute__((unused))
+// #define ATTR_UNUSED __attribute__((unused))
+// Prefer: Just don't give those parameters a name (or comment the name) in the implementation
+// => will work for all compilers and doesn't require macro
+
 
 // for math: INFINITY and NAN macros
 #ifndef _GNU_SOURCE

--- a/src/data_param.h
+++ b/src/data_param.h
@@ -99,7 +99,7 @@ public:
     }
 
     // implements Data::export_csv()
-    bool export_csv(const std::string & filename, const std::string & sep ATTR_UNUSED = std::string(",")) const {
+    bool export_csv(const std::string & filename, const std::string & /*sep*/ = std::string(",")) const {
         std::ofstream fout(filename.c_str());
 
         if (!fout.is_open()) return false;

--- a/src/filefun.cpp
+++ b/src/filefun.cpp
@@ -24,14 +24,22 @@
 #include <algorithm>
 #include <limits.h>
 #include <stdlib.h>
-#include <libgen.h>
+#ifdef _MSC_VER
+    #include <io.h> // _access
+    #define F_OK 0
+    #ifndef access
+        #define access _access
+    #endif // !access
+#else
+    #include <unistd.h> // access, F_OK
+#endif // !_MSC_VER
+
 #include "filefun.h"
-#include <unistd.h>
 
 using namespace std;
 
-#if defined(WIN32) || defined(__WIN32) || defined(__WIN32__)
-	#define realpath(N,R) _fullpath((R),(N),_MAX_PATH)
+#if defined(WIN32) || defined(__WIN32) || defined(__WIN32__) || _MSC_VER
+    #define realpath(N,R) _fullpath((R),(N),_MAX_PATH)
 #endif
 
 string getFullPath(const string & filename) {

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -21,11 +21,11 @@
     
  */
 
-#include <sys/time.h>
+#include <chrono>
+#include <thread>
 #include <sstream>
 //#include <stdlib.h>
 #include <iostream>
-#include <unistd.h>
 #include "logger.h"
 #include "filefun.h"
 
@@ -135,11 +135,10 @@ ofstream* Logger:: _createLogfile(std::string filename) {
     // gamble filename
     _fname << filename << "_";
 
-    struct timeval now;
-    long millitime;
-    gettimeofday(&now, NULL);
-    millitime = (now.tv_sec * 1000 + now.tv_usec/1000.0);
-    _fname << millitime << ".txt";
+    using namespace std::chrono;
+    auto now_milli = time_point_cast<milliseconds>(system_clock::now());
+
+    _fname << now_milli.time_since_epoch().count() << ".txt";
     fullname = _fname.str();
 
     ofstream*log = new ofstream;
@@ -151,7 +150,7 @@ ofstream* Logger:: _createLogfile(std::string filename) {
         log->open(fullname.c_str());
         cout << "Log file created: " << fullname << endl;        
     }
-    usleep(5E-3);// FIXME: because of time resolution, we have to wait here for a while. otherwise we could be asked to create a log of logfiles, and it would oftentimes fail
+    this_thread::sleep_for(milliseconds{ 5 });// FIXME: because of time resolution, we have to wait here for a while. otherwise we could be asked to create a log of logfiles, and it would oftentimes fail
     return log;
 }
 

--- a/src/onboardlogparser_apm.cpp
+++ b/src/onboardlogparser_apm.cpp
@@ -113,7 +113,7 @@ bool OnboardLogParserAPM::_parse_message(const csv_row & row, OnboardData & ret)
                 break;
 
             case 'Q':
-                ret._uint_data[colname] = ((u_int64_t) atoll(row[k].c_str()));
+                ret._uint_data[colname] = ((uint64_t) atoll(row[k].c_str()));
                 break;
 
             case 'M': // mode-string

--- a/src/time_fun.cpp
+++ b/src/time_fun.cpp
@@ -29,22 +29,23 @@
 #include <sstream>
 #include <string.h> // memset
 #include <math.h>
+#include <chrono>
 #include "time_fun.h"
 #include "stringfun.h"
 
-#if defined(WIN32) || defined(__WIN32) || defined(__WIN32__)
+#if defined(WIN32) || defined(__WIN32) || defined(__WIN32__) || defined(_MSC_VER)
 #else
 #include <sys/time.h>
 #endif
 
 using namespace std;
 
-#if defined(WIN32) || defined(__WIN32) || defined(__WIN32__)
+#if defined(WIN32) || defined(__WIN32) || defined(__WIN32__) || defined(_MSC_VER)
 #include <ctype.h>
 #include <string.h>
 #include <time.h>
- 
- 
+
+
 /*
  * We do not implement alternate representations. However, we always
  * check whether a given modifier is allowed for a certain conversion.
@@ -422,21 +423,18 @@ int strncasecmp(char *s1, char *s2, size_t n)
         s1++;
         s2++;
     }
- 
+
     return tolower(*(unsigned char *) s1) - tolower(*(unsigned char *) s2);
 }
-
-double get_time_secs(void) {
-    return 0.; // TODO
-}
-
-#else /* NOT WIN32" */
-double get_time_secs(void) {
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    return ((double)(tv.tv_sec + (tv.tv_usec / 1E6)));
-}
 #endif /* WIN32 */
+
+double get_time_secs(void) {
+    using namespace std::chrono;
+    using float_sec_t = duration<double>;
+
+    const auto now = time_point_cast<float_sec_t>(system_clock::now());
+    return now.time_since_epoch().count();
+}
 
 struct tm epoch_to_tm(double epoch_sec) {
     time_t epoch_sec_t = (time_t) round(epoch_sec);


### PR DESCRIPTION
- *Requires c++11 or newer!*
- Tested only with MSVC 2017 and g++5.4 and qwt 6.1.3
- This port should work with 
   - MSVC 2015 and newer
   - gcc >=4.8
   - clang >= 3.5
- Based on https://github.com/mbeckersys/MavLogAnalyzer/pull/4

Main changes:
- Provides comilation flags specific to MSVC or c++11
- Replaces unix specific code with c++11 facilities where available
- Deactivates commandline parsing for MSVC
